### PR TITLE
Linux support and other fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,63 @@
+cmake_minimum_required(VERSION 3.20)
+project(VisionDemos)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+option(ASAN "enable asan/ubsan")
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wvla -Wno-missing-field-initializers -Wno-unused-parameter -Wno-unknown-pragmas")
+	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -O0")
+	if (ASAN)
+		set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fsanitize=address -fsanitize=undefined")
+	endif()
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
+endif()
+
+add_executable(vision Image.cpp
+                      lib/imgui-docking/backends/imgui_impl_glfw.cpp
+                      lib/imgui-docking/backends/imgui_impl_opengl3.cpp
+                      lib/imgui-docking/imgui.cpp
+                      lib/imgui-docking/imgui_draw.cpp
+                      lib/imgui-docking/imgui_tables.cpp
+                      lib/imgui-docking/imgui_widgets.cpp
+                      lib/imgui-docking/misc/cpp/imgui_stdlib.cpp
+                      lib/imnodes-master/imnodes.cpp
+                      MRU.cpp
+                      NodeList.cpp
+                      nodes/Node.cpp
+                      nodes/NodeAdd.cpp
+                      nodes/NodeAnd.cpp
+                      nodes/NodeCameraStream.cpp
+                      nodes/NodeCanny.cpp
+                      nodes/NodeContours.cpp
+                      nodes/NodeConvolve.cpp
+                      nodes/NodeCrop.cpp
+                      nodes/NodeDilate.cpp
+                      nodes/NodeDistanceTransform.cpp
+                      nodes/NodeErode.cpp
+                      nodes/NodeGaussianBlur.cpp
+                      nodes/NodeHistogram.cpp
+                      nodes/NodeImageLoad.cpp
+                      nodes/NodeInRange.cpp
+                      nodes/NodeMultiply.cpp
+                      nodes/NodeNormalize.cpp
+                      nodes/NodeOutput.cpp
+                      nodes/NodeConvertColor.cpp
+                      nodes/NodeResize.cpp
+                      nodes/NodeSubtract.cpp
+                      nodes/NodeThreshold.cpp
+                      Pin.cpp
+                      VisionDemos.cpp)
+
+target_include_directories(vision PUBLIC "${CMAKE_SOURCE_DIR}/lib/imgui-docking/"
+                                         "${CMAKE_SOURCE_DIR}/lib/imgui-docking/backends/"
+                                         "${CMAKE_SOURCE_DIR}/lib/json-develop/single_include/nlohmann/"
+                                         "${CMAKE_SOURCE_DIR}/lib/imnodes-master/") 
+
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(deps REQUIRED IMPORTED_TARGET opencv4 glfw3 opengl)
+target_link_libraries(vision PUBLIC PkgConfig::deps)

--- a/MRU.cpp
+++ b/MRU.cpp
@@ -1,5 +1,6 @@
 #include "MRU.h"
 #include <fstream>
+#include <algorithm>
 
 MRU::MRU()
 {

--- a/VisionDemos.cpp
+++ b/VisionDemos.cpp
@@ -522,7 +522,7 @@ std::string GetLoadFileName()
 }
 #else
 std::string GetLoadFileName() { return "file.vision"; }
-std::string GetSaveFileName(std::string defaultFilename = "") { return "file.vision"; }
+std::string GetSaveFileName(std::string defaultFilename) { return "file.vision"; }
 #endif
 
 

--- a/nodes/Node.cpp
+++ b/nodes/Node.cpp
@@ -56,6 +56,12 @@ Node::Node(const json& j)
     }
 }
 
+Node::~Node()
+{
+    delete[] inputPins;
+    delete[] outputPins;
+}
+
 void Node::setImage3OutputPin(int index, Image3& image, bool fromJson)
 {
     if (index + 3 >= outputs)

--- a/nodes/Node.h
+++ b/nodes/Node.h
@@ -62,6 +62,7 @@ public:
     virtual cv::Mat getPinImage1(int pinId);;
     virtual int getPinInt(int pinId) { throw "oops"; };
 
+	virtual ~Node();
 protected:
     Node(const NodeType t, int id, int inputs, int outputs, int& currentPinId);
 

--- a/nodes/NodeCameraStream.cpp
+++ b/nodes/NodeCameraStream.cpp
@@ -6,13 +6,13 @@ NodeCameraStream::NodeCameraStream(int id, int& currentPinId) : Node(NodeType::C
 {
     cameraId = 0;
     setImage3OutputPin(0, image);
-    cap = new cv::VideoCapture(cameraId, cv::CAP_DSHOW);
+    cap = new cv::VideoCapture(cameraId);
 }
 NodeCameraStream::NodeCameraStream(const json& j) : Node(j)
 {
     cameraId = j["cameraId"];
     image.threeComponent = j["threecomponent"];
-    cap = new cv::VideoCapture(cameraId, cv::CAP_DSHOW);
+    cap = new cv::VideoCapture(cameraId);
     setImage3OutputPin(0, image, true);
 }
 void to_json(json& j, const NodeCameraStream& node) {

--- a/nodes/NodeCameraStream.cpp
+++ b/nodes/NodeCameraStream.cpp
@@ -15,6 +15,13 @@ NodeCameraStream::NodeCameraStream(const json& j) : Node(j)
     cap = new cv::VideoCapture(cameraId);
     setImage3OutputPin(0, image, true);
 }
+
+NodeCameraStream::~NodeCameraStream()
+{
+    cap->release();
+    delete cap;
+}
+
 void to_json(json& j, const NodeCameraStream& node) {
     j["cameraId"] = node.cameraId;
     j["threecomponent"] = node.image.threeComponent;

--- a/nodes/NodeCameraStream.h
+++ b/nodes/NodeCameraStream.h
@@ -12,6 +12,7 @@ public:
     int cameraId;
     NodeCameraStream(int id, int& currentPinId);
     NodeCameraStream(const json& j);
+    ~NodeCameraStream();
 
     void compute(const NodeList& nodes) override;
     void render() override;

--- a/nodes/NodeResize.cpp
+++ b/nodes/NodeResize.cpp
@@ -25,7 +25,7 @@ void NodeResize::render()
     renderInputFloat("Width%", -1, percX);
     renderInputFloat("Height%", -1, percY);
 
-    if (ImGui::Combo("Type", &interType, "Nearest\0Linear\0Cubic\0Area\0Lanczos4\0Linear Exact\nNearest Exact"))
+    if (ImGui::Combo("Type", &interType, "Nearest\0Linear\0Cubic\0Area\0Lanczos4\0Linear Exact\nNearest Exact\0"))
         computed = false;
 
     renderOutputImage("Image", 0, image);

--- a/nodes/NodeThreshold.cpp
+++ b/nodes/NodeThreshold.cpp
@@ -25,7 +25,7 @@ void NodeThreshold::render()
     renderInputInt("Threshold", 1, threshold);
     renderInputInt("Max Value", 2, maxValue);
     
-    if (ImGui::Combo("Type", &thresholdType, "Binary\0Binary_Inv\0Trunc\0ToZero\0ToZero_Inv\0Mask\0Otsu\0Triangle"))
+    if (ImGui::Combo("Type", &thresholdType, "Binary\0Binary_Inv\0Trunc\0ToZero\0ToZero_Inv\0Mask\0Otsu\0Triangle\0"))
         computed = false;
 
 


### PR DESCRIPTION
Add a CMake file for building under Linux, it cannot currently be used for building under Windows, the CMake file would need to be changed to use the dependencies shipped in the lib directory.

Building under Linux requires pkgconf, opencv 4, glfw 3 and libglvnd.

Fix camera initialisation on linux by auto detecting format rather than forcing DirectShow.

Fix memory leak on deletion of any node as well as NodeCameraStream.

Also fixes a missing `#include` statement, a double definition of a default parameter and missing null characters in the strings used to construct ImGui combo boxes (the implicit null terminator of a string literal is not enough, it needs to end with two of them).